### PR TITLE
Feature/support

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -3,211 +3,343 @@
 ### What is the best way to raise an issue?
 If you have a precise question it might be already answered on our support page,
 if not we encourage you to raise your point in our community center where you can find help from us or other users.
+
 More and more of our apps also have a "help" (or "support") button built-in, which we recommend.
-If you would rather address us directly send us an email at support@pryv.com: we are bound to confidentiality by our HIPAA certificate.
+
+If you would rather address us directly send us an email at [support@pryv.com](mailto:support@pryv.com): we are bound to confidentiality by our HIPAA certificate.
 
 ### How do I create an account?
-To create your account simply click on this link. Then simply follow the steps that are required, to create your account we will need
-your email address: this way we can help you if you were to loose your password or contact you to tell you about our latest news
-a username of your choosing as long as no one else took it
-a password that has a minimum of 6 characters
-a location to store your data of your choosing.
-The last point is rather important as by choosing the location that is the closest to you, you grant yourself a way to complain in case your data are stolen or if you'd rather benefit from your homeland regulation for data protection.
+To create your account simply click on this [link](https://sw.pryv.me/access/register.html).
+
+Then simply follow the steps that are required, to create your account we will need:
+    - your email address: this way we can help you if you were to loose your password or contact you to tell you about our latest news
+    - a username of your choosing as long as no one else took it
+    - a password that has a minimum of 6 characters
+    - a location to store your data of your choosing.
+    
+The last point is rather important as by choosing the location that is the closest to you,
+you grant yourself a way to complain in case your data are stolen or if you'd rather benefit from your homeland regulation for data protection.
+
 ### What can I do with Pryv?
-We designed Pryv to support many different usages and are working to provide you with more ways to really feel in full control of your data. That being said we also created test/demo accounts such as Christine. Christine is an active mother: she loves to run and have a devouring passion for arts. She enjoys taking care of her family and cooking. We invite you to check her account and why not add it to your Pryv. Be sure that other will come in the days to come.
+We designed Pryv to support many different usages and are working to provide you with more ways to really feel in full control of your data.
+
+That being said we also created test/demo accounts such as Christine.
+Christine is an active mother: she loves to run and have a devouring passion for arts.
+She enjoys taking care of her family and cooking. We invite you to check her account and why not add it to your Pryv.
+Be sure that other will come in the days to come.
 
 We're looking forward to see how you're going to use it, please feel free to share with us or with other how you use Pryv.
 
 ### How much data can I upload on my Prvy?
-At the moment there is no storage limit, but we may get in touch to discuss if your account gets big enough to become an issue for us. In the short term we will set a reasonable limit for uploads to make things clearer.
-As we get closer to the end of our Beta phase, we will define the exact conditions for free and paid/sponsored accounts. As the infrastructure required to run Pryv isn't free, paid accounts are the only real guarantee we can offer that our goals are aligned with yours (so that you are not the product). We'll provide more information about future pricing on our website as soon as we can.
+At the moment there is no storage limit, but we may get in touch to discuss if your account gets big enough to become an issue for us.
+In the short term we will set a reasonable limit for uploads to make things clearer.
+
+As we get closer to the end of our Beta phase, we will define the exact conditions for free and paid/sponsored accounts.
+As the infrastructure required to run Pryv isn't free, paid accounts are the only real guarantee we can offer that our goals are aligned with yours
+(so that you are not the product).
+
+We'll provide more information about future pricing on our website as soon as we can.
 
 ### What is a stream?
-A stream is a category for content. It regroups content that occurs in a given context such as traveling, family, hobbies, games, friends, etc. A stream represents an aspect of your life.
+A stream is a category for content. It regroups content that occurs in a given context such as traveling, family, hobbies, games, friends, etc.
+
+A stream represents an aspect of your life.
+
 A stream can have sub-streams. For example "Traveling" could contain "Belgium", "Sweden" and "Brittany"; "Family" could contain "kids", "grandma" and "dog".
 
 ### What is a slice of life?
-A slice of life is a set of streams that you want to view together. For example, you will probably want to view your running performance together with your health metrics and maybe share that with your trainer. Or view your travel logs, kids photos and notes to share with Grandma. 
+A slice of life is a set of streams that you want to view together.
+
+For example, you will probably want to view your running performance together with your health metrics and maybe share that with your trainer.
+Or view your travel logs, kids photos and notes to share with Grandma. 
+
 ### What about Android?
 We are fully aware of the growing number of Android users and we will deliver Pryv for Android as soon as possible. We plan that to be by the end the year. 
+
 ## ACCOUNT & REGISTRATION
 ### I was asked where I want my data stored, what does that mean?
-Pryv gives you full control over your data. That also means choosing the country and thus the legal environment in which your data is stored. This enables you to:
-Put your data where you think it is the safest for you
-Defend your rights and protect your privacy in the legal frame you choose
+Pryv gives you full control over your data. That also means choosing the country and thus the legal environment in which your data is stored.
+
+This enables you to:
+    - Put your data where you think it is the safest for you
+    - Defend your rights and protect your privacy in the legal frame you choose
 
 # Browser / Web app
-
 ## FAQ
 Here you can ask us anything regarding the browser version of Pryv. Feel free to tell us about any bug, UI issue or glitches you may have found.
+
 ### How can I change my profile picture?
-To change your Pryv profile picture, you have to set up a Gravatar account with the same email you are using on Pryv (https://en.gravatar.com/ ) Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+To change your Pryv profile picture, you have to set up a [Gravatar](https://en.gravatar.com) account with the same email you are using on Pryv.
+
+Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+
 ### How can I change my password?
-To change your password click on your username to access the setting panel. Once openned click on the "security" panel to access password modification 
+To change your password click on your username to access the setting panel.
+
+Once opened click on the "security" panel to access password modification 
+
 ### How can I disconnect apps from my Pryv?
-To disconnect apps from your Pryv you need to go in you setting panel that is accessible when you click on your username on the top right corner of your screen. The click on setting to get to the list of apps that are currently connected to your account. To disconnect any of them simply click on "disconnect" and the app will disappear from your list. 
+To disconnect apps from your Pryv you need to go in you setting panel that is accessible when you click on your username on the top right corner of your screen.
+
+Then click on setting to get to the list of apps that are currently connected to your account.
+
+To disconnect any of them simply click on "disconnect" and the app will disappear from your list. 
+
 ### Will I be able to download my data back to my computer?
-There will definitely be an export function: as we often say your data is yours and yours alone. If you wish to retrieve your data back to your computer you definitely need to be able to. We are working on it as we speak but we'd be very interested to know under which format you'd like to receive your data so don't hesitate to leave us a comment or to contact us. 
+There will definitely be an export function: as we often say your data is yours and yours alone.
+If you wish to retrieve your data back to your computer you definitely need to be able to.
+
+We are working on it as we speak but we'd be very interested to know under which format you'd like to receive your data
+so don't hesitate to leave us a comment or to contact us. 
+
 ### How can I add, delete, move or rename a stream?
 Today you can create stream when adding new items to your Pryv with our web app, when importing pictures, notes or position from the CSV importer or with Pryv for iOS.
-At the moment there is no way to manage your streams other than when adding new items, we are aware that the absence of stream management is one of the biggest pain at the moment and we are planning to solve that by releasing an update for Pryv in the days to come. We'll keep you updated on our blog.
+
+At the moment there is no way to manage your streams other than when adding new items, we are aware that the absence of stream management
+is one of the biggest pain at the moment and we are planning to solve that by releasing an update for Pryv in the days to come.
+We'll keep you updated on our blog.
+
 ### I have imported pictures (or other content) but I don't see them, why?
-f after importing pictures (or other content, e.g. with the CSV importer) you don't see them, or only see some of them, check the period of time (and maybe the streams) you're looking at. Most likely what you've added is outside (past) the currently selected time frame, which you can adjust with the bottom navigation controls. 
+If after importing pictures (or other content, e.g. with the CSV importer) you don't see them, or only see some of them,
+check the period of time (and maybe the streams) you're looking at.
+
+Most likely what you've added is outside (past) the currently selected time frame, which you can adjust with the bottom navigation controls. 
+
 ### How do I edit positions?
 To edit a geographical position, choose Edit, then just drag the marker to the desired location on the map (and don't forget to Save your change).
+
 In the future we'll add location search to make adding and editing positions easier.
+
 ### How to import more than one picture at the same time?
-In the window that opens to select what file to upload, you can select multiple files by keeping pressed SHIFT or COMMAND (Mac) / CONTROL (Linux/Windows) on your keyboard. 
+In the window that opens to select what file to upload, you can select multiple files 
+by keeping pressed SHIFT or COMMAND (Mac) / CONTROL (Linux/Windows) on your keyboard. 
+
 ### Which browser should I be using?
-Our reference browser for development is Chrome for Mac, Windows and Linux but Pryv also works well on Firefox. As of today we have not yet been able to seriously test it on other browsers, so we can't promise the best of experiences on the likes of Safari, Opera or Internet Explorer. Please tell us in the comments if you would like us to work more on one or the other. 
+Our reference browser for development is Chrome for Mac, Windows and Linux but Pryv also works well on Firefox.
+
+As of today we have not yet been able to seriously test it on other browsers,
+so we can't promise the best of experiences on the likes of Safari, Opera or Internet Explorer.
+
+Please tell us if you would like us to work more on one or the other. 
 
 ## SHARING & SLICES
 ### What happens when I share my content through Facebook or Twitter?
-When you share a slice of life on Facebook, Twitter or other services you only share an access to your content, i.e. you do not provide the content itself. This enables you to share without giving up your rights to your content as everything stays on your account (and thus under your control). It also means you can revoke access to your content in a few clicks, immediately removing access rights for whomever had received the sharing link. 
+When you share a slice of life on Facebook, Twitter or other services you only share an access to your content, i.e. you do not provide the content itself.
+
+This enables you to share without giving up your rights to your content as everything stays on your account (and thus under your control).
+It also means you can revoke access to your content in a few clicks, immediately removing access rights for whomever had received the sharing link. 
+
 ### Someone shared a slice with me, how can I keep it in my account?
-In Pryv you can not only see what your relatives or friends share with you, but you can also seamlessly integrate it into your own Pryv account. To do so, when you've opened the sharing link on Pryv (and signed in if necessary), simply open the left side drawer and choose Follow this slice. 
+In Pryv you can not only see what your relatives or friends share with you, but you can also seamlessly integrate it into your own Pryv account.
+
+To do so, when you've opened the sharing link on Pryv (and signed in if necessary), simply open the left side drawer and choose Follow this slice. 
 Once that's done, just go to your own account to see the followed slice the same way you see your own content, including real-time updates.
 
 ### How can I share content?
-Pryv allows you to share content with friends or relatives whether or not they have a Pryv account, by giving them access to a selected set of streams (i.e. a slice of life).
-To share a slice of life, open the left panel , select the desired streams (checking the corresponding content in the view that updates in real time), then choose Share a slice. You can then enter a name to identify that shared slice, change access permissions if needed (more on that below), double-check the streams you're sharing, and after you've confirmed (with the Share button) share the link on Twitter, Facebook or with an e-mail.
+Pryv allows you to share content with friends or relatives whether or not they have a Pryv account,
+by giving them access to a selected set of streams (i.e. a slice of life).
+
+To share a slice of life, open the left panel , select the desired streams (checking the corresponding content in the view that updates in real time),
+then choose Share a slice.
+
+You can then enter a name to identify that shared slice, change access permissions if needed (more on that below),
+double-check the streams you're sharing, and after you've confirmed (with the Share button) share the link on Twitter, Facebook or with an e-mail.
  
 What is actually shared?
-In Pryv you don't share individual content items (like a picture, a note, etc.), you share streams of content. People you've shared with will then be able to access all the content in those selected streams, including past and new content (updated in real time), with even the ability to contribute if you choose so. You can see for yourself what a shared slice can look like by opening Christine's sharing.
+In Pryv you don't share individual content items (like a picture, a note, etc.), you share streams of content.
+People you've shared with will then be able to access all the content in those selected streams, including past and new content (updated in real time),
+with even the ability to contribute if you choose so.
+You can see for yourself what a shared slice can look like by opening Christine's sharing.
  
 About permissions
 There are 3 levels of permissions:
-Allow read only: people you share with can only view the content
-Allow contributing content: people can also add and edit content (pictures, notes, etc.)
-Allow managing content and streams: people can contribute but also add, edit and delete sub-streams
+    - Allow read only: people you share with can only view the content
+    - Allow contributing content: people can also add and edit content (pictures, notes, etc.)
+    - Allow managing content and streams: people can contribute but also add, edit and delete sub-streams
  
 Your feedback
-Feel free to tell us what you use sharing for (or suggest other ways you'd like to share content) in the comments. We're looking forward to it.
+Feel free to tell us what you use sharing for (or suggest other ways you'd like to share content), we're looking forward to it.
 
 ### I added a shared slice, does it consume my storage?
-No. When someone shares a slice with you the data remains on that person's account. This means the data does not count as part of your personal storage. 
+No. When someone shares a slice with you the data remains on that person's account.
+
+This means the data does not count as part of your personal storage. 
+
 ### I shared a slice but how can I revoke it?
-Open the left panel and go to Manage slices, which lists all the slices you have shared. From there you can locate your slice and delete it instantly. Once deleted no one else will be able to access it anymore. 
+Open the left panel and go to Manage slices, which lists all the slices you have shared.
+From there you can locate your slice and delete it instantly.
+
+Once deleted no one else will be able to access it anymore. 
 
 ## QUICK SETUP
 ### How can I change my profile picture?
-To change your Pryv profile picture, you have to set up a Gravatar account with the same email you are using on Pryv (https://en.gravatar.com/ ) Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+To change your Pryv profile picture, you have to set up a [Gravatar](https://en.gravatar.com) account with the same email you are using on Pryv.
+Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+
 ### How can I see more of my content?
-The main navigation tool on Pryv is the time bar at the bottom. By clicking on its elements you'll be able to navigate through years, months, weeks or days. For more customization you cal also choose the "custom" button to select the time frame you wish to display.
-You can also choose to reduce or increase the amount of streams to display by using the drawer on the right side of your screen. Check or uncheck the streams you want to see
+The main navigation tool on Pryv is the time bar at the bottom. By clicking on its elements you'll be able to navigate through years, months, weeks or days.
+
+For more customization you can also choose the "custom" button to select the time frame you wish to display.
+
+You can also choose to reduce or increase the amount of streams to display by using the drawer on the right side of your screen.
+Check or uncheck the streams you want to see
 
 ### How can I add a note?
 To add a note click on the "add content" menu  and then on the note button.
-Once in the note edition mode just type your note, choose the stream you want your data to be stored in and click on add to save. You can also add tags or a description to it before saving.
+Once in the note edition mode just type your note, choose the stream you want your data to be stored in and click on add to save.
+
+You can also add tags or a description to it before saving.
 
 ### How can I add a position?
 As for all content creation first click on "add content"  and then on position.
-When in the "add position" menu you'll be asked if you want your position to be added, if yes agree to the question and if not you'll automatically be located in Switzerland. To change the position drag and drop the red marker to your desired position.
+When in the "add position" menu you'll be asked if you want your position to be added,
+if yes agree to the question and if not you'll automatically be located in Switzerland.
+
+To change the position drag and drop the red marker to your desired position.
 Then choose the stream where you want this data to be saved and click on add to save the position.
 
 ### How can I do add pictures?
 From the browser you can add pictures by using the "add content" button.
-When you are in the add content menu simply choose the picture menu and click on "select pictures to upload". You can import multiples elements by holding the shift button down when clinking on the pictures you want to import. 
-Choose the stream where you want your pictures to be and then on import. Wait for the window to close itself to display the pictures in your Pryv.
+When you are in the add content menu simply choose the picture menu and click on "select pictures to upload".
+You can import multiples elements by holding the shift button down when clinking on the pictures you want to import. 
+Choose the stream where you want your pictures to be and then on import.
+Wait for the window to close itself to display the pictures in your Pryv.
 
 ### I just created an account, what now?
-Congratulations and welcome on Pryv. Before arriving to your account you'll see a few slides describing what Pryv is as well as Christine's account. With Christine you'll see a great deal of what Pryv is about.
+Congratulations and welcome on Pryv.
+
+Before arriving to your account you'll see a few slides describing what Pryv is as well as Christine's account.
+With Christine you'll see a great deal of what Pryv is about.
+
 You will then have the choice between adding your own content (pictures, notes or position) or adding an app of your choosing.
-We are now going to see how to add your content, as there will be a dedicated article for each app connexion. First you will need to click on the "add content" button. It's located on your top left screen.
-By clicking on "add content" you will open the following window. From here you can choose between adding a note, a picture or a location or even upload a CSV file.
+We are now going to see how to add your content, as there will be a dedicated article for each app connexion.
+
+First you will need to click on the "add content" button. It's located on your top left screen.
+By clicking on "add content" you will open the following window.
+From here you can choose between adding a note, a picture or a location or even upload a CSV file.
  
-Once you've added your content you'll need to choose the stream in which you want the content to be. Your streams will appear on the right of your window, just click on one to choose it or to open the substream creation menu. If you decide to create a new stream your content will be imported in it at the same time as the stream will be create.
+Once you've added your content you'll need to choose the stream in which you want the content to be.
+Your streams will appear on the right of your window, just click on one to choose it or to open the substream creation menu.
+If you decide to create a new stream your content will be imported in it at the same time as the stream will be create.
  
 When this is done simply enjoy the visualization of your content and why not share it with friends?
 
-
 # iOS app
-
 ## SUPPORT RELATIVE TO PRYV ON IOS
 ### Why do I keep seeing the red slides?
-The 3 onboarding slides appear when there is no content to display (this is an issue that will be fixed in the future). To make them disappear, either add content or select streams with content in the left drawer. 
+The 3 onboarding slides appear when there is no content to display (this is an issue that will be fixed in the future).
+
+To make them disappear, either add content or select streams with content in the left drawer. 
+
 ### Where can I see all the content I enter into the app?
-To access all the content you create in Pryv iOS (or other apps like Pryv At or Pryv OSX), we invite you to sign into your account from pryv.me from a laptop or desktop computer. You'll be able to view, navigate and enjoy all your content at a glance with our dynamic visualization. 
+To access all the content you create in Pryv iOS (or other apps like Pryv At or Pryv OSX), we invite you to sign into your account
+from pryv.me from a laptop or desktop computer.
+
+You'll be able to view, navigate and enjoy all your content at a glance with our dynamic visualization. 
+
 ### When I tap on '+' to add content there is a long empty list, what's that for?
-That space is used to display shortcuts for the most recently added content. Those shortcuts are automatically created each time you add a new item to your Pryv from the app, and save you time by pre-selecting the content type, stream and tags for new content.  
+That space is used to display shortcuts for the most recently added content.
+
+Those shortcuts are automatically created each time you add a new item to your Pryv from the app,
+and save you time by pre-selecting the content type, stream and tags for new content.  
+
 ### Why can't I see my positions in the app?
-For the moment the iOS app does not support positions. We'll add that in the future, but in the meantime you can use the very simple app Pryv At which does just that. Thanks for your patience and support. 
+For the moment the iOS app does not support positions.
+
+We'll add that in the future, but in the meantime you can use the very simple app Pryv At which does just that.
+Thanks for your patience and support. 
 
 # Connected apps
-
 ## CSV IMPORTER
 ### A step by step guide to importing CSV files
-We got a few questions about how to import multiple numerical data into Pryv without going trough the iPhone app and we wanted to provide you with a complete guide on how to use our CSV importer.
-1. Get your CSV file, it's the only format that can be uploaded right now but save your excel files as CSV by choosing to "save as" and selecting the CSV format in the drop down menu.
-2. Get to the CSV importer either from your connected app section or by using this link.
-3. Start by signing in in using the red button on the top right button
-4. Once logged in simply drag and drop your file onto the delimited zone or click on it to open your explorer / finder
-5. The next step requires you to select the unit you want to import, you can either use the search bar at the top or scroll in the menu. You'll need to select the type and the unit, both are required to continue, as long as both are not selected you will not be able to continue.
-6. You then need to select the content of each column, you'll need at least a "time" and a "content" field to continue. When you select time be careful of the format, you might need to change the default selection to fit your requirements, you can check it with the date inserted in brackets that displays how you date will be imported. Do not forget to skip the first row if you used it to enter the title of the column.
-7. Then simply select which stream you would like your data to be imputed or create a new one by entering its name, choosing where you want it to be and clinking on the + then select "confirm".
-8. Once the download is complete you can either cancel it by using the "rollback" button, start importing a new CSV file with "back" or simply enjoy your content in your Pryv by clicking on "go to my Pryv".
+We got a few questions about how to import multiple numerical data into Pryv without going trough the iPhone app
+and we wanted to provide you with a complete guide on how to use our CSV importer.
+    1. Get your CSV file, it's the only format that can be uploaded right now but save your excel files as CSV by choosing to "save as"
+    and selecting the CSV format in the drop down menu.
+    2. Get to the CSV importer either from your connected app section or by using this link.
+    3. Start by signing in in using the red button on the top right button
+    4. Once logged in simply drag and drop your file onto the delimited zone or click on it to open your explorer / finder
+    5. The next step requires you to select the unit you want to import, you can either use the search bar at the top or scroll in the menu.
+    You'll need to select the type and the unit, both are required to continue, as long as both are not selected you will not be able to continue.
+    6. You then need to select the content of each column, you'll need at least a "time" and a "content" field to continue.
+    When you select time be careful of the format, you might need to change the default selection to fit your requirements,
+    you can check it with the date inserted in brackets that displays how you date will be imported.
+    Do not forget to skip the first row if you used it to enter the title of the column.
+    7. Then simply select which stream you would like your data to be imputed or create a new one by entering its name,
+    choosing where you want it to be and clinking on the + then select "confirm".
+    8. Once the download is complete you can either cancel it by using the "rollback" button,
+    start importing a new CSV file with "back" or simply enjoy your content in your Pryv by clicking on "go to my Pryv".
  
-We hope you'll enjoy importing you CSV files and enjoy them in your own Pryv. Would you have any issue please do not hesitate to contact us or to leave us a comment below.
+We hope you'll enjoy importing you CSV files and enjoy them in your own Pryv.
+Would you have any issue please do not hesitate to contact us.
 
 ### I can't find my desired unit, what can I do?
-We are aware that there are thousand of types of units and so far we've tried to offer all most used ones and those for which we had the most demand. If you feel that some unique or even original measure you'd like to use is missing please don't hesitate to add a comment below or contact us directly. 
+We are aware that there are thousand of types of units and so far we've tried to offer all most used ones and those for which we had the most demand.
+If you feel that some unique or even original measure you'd like to use is missing please don't hesitate to add a comment below or contact us directly. 
+
 ### What is EpochTime?
-If you are new to CSV files you may be surprised to see the word EpochTime in your time column. EpochTime is a way to count time in seconds, therefore you may have something like that: "1372507199.9995", in everyday English it is the same thing as Sat, Jun 29 2013 1:59 PM). If you are dealing with this kind of time stamp and you want to import them to your Pryv no problem: just enter X (in upper case) instead of the time and we will translate it instantly for you. 
+If you are new to CSV files you may be surprised to see the word EpochTime in your time column.
+EpochTime is a way to count time in seconds, therefore you may have something like that: "1372507199.9995",
+in everyday English it is the same thing as Sat, Jun 29 2013 1:59 PM).
+
+If you are dealing with this kind of time stamp and you want to import them to your Pryv no problem:
+just enter X (in upper case) instead of the time and we will translate it instantly for you. 
 
 ## PRYV AT
 ### How can I limit or increase the amount of positions taken?
-There are several options you can use to increase or decrease the amount of position taken by the app. You can modify the distance between each new captured position or the time between new captures by simply going on the setting page on the bottom right corner of the screen.
-By modifying theses settings you will also change the impact that the app will have on your battery: the more position you want to take the more battery it will consume, if, on another hand, you're just looking for a simple way to keep simple records of your whereabouts you can limit the amount of position taken and by doing so increase you battery lifespan.
+There are several options you can use to increase or decrease the amount of position taken by the app.
+You can modify the distance between each new captured position or the time between new captures
+by simply going on the setting page on the bottom right corner of the screen.
+
+By modifying theses settings you will also change the impact that the app will have on your battery:
+the more position you want to take the more battery it will consume, if,
+on another hand, you're just looking for a simple way to keep simple records of your whereabouts you can limit the amount of position taken
+and by doing so increase you battery lifespan.
 
 
 ## PRYV FOR OS X
 ### Can I import multiple elements at once?
-At the moment you can only import events one by one but multiple elements importation is something that should be arriving very soon so stay tunned and don't miss your app updates. 
+At the moment you can only import events one by one but multiple elements importation is something that should be arriving very soon so stay tuned
+and don't miss your app updates. 
 
 ## 3RD PARTY APPS
 ### How can I add my Withings account to my Pryv?
 The first thing you'll need to do to connect your Withings account is to go on "connect apps" from your desktop or click on this link.
-This will trigger a new window to open where you'll be asked to login from the button on the top right corner of your screen. This will open a pop-up to ask you the permission to create a new stream dedicated to receiving your Withings data. If you decide to reject your data won't be uploaded and the Withings stream won't be created.
+This will trigger a new window to open where you'll be asked to login from the button on the top right corner of your screen.
+This will open a pop-up to ask you the permission to create a new stream dedicated to receiving your Withings data.
+If you decide to reject your data won't be uploaded and the Withings stream won't be created.
 Once you accepted you will get a last confirmation screen to tell you that all new data will now be imported to your Pryv account in its dedicated stream.
 
 ### How can I connect with my Twitter account to my Pryv?
-First you need to click on the "connect app" button from your laptop or desktop or click on this link, then click on "connect" under the Twitter logo. This will bring you on our Twitter bridge.
-Once there you'll have to sign in using the button on the top right corner of your screen and enter your credentials. This will trigger a popup to open to ask you to allow Twitter to publish on your Pryv, it will also create a Twitter stream to store your data
-The next window will enable you to choose the Tweets that should be sent to your Pryv. The first box will enable you to refine the Tweets that will be sent to your Pryv: you can choose to import all tweets, only favorites or those that fits a specific text. Finally you will also be enabled to import your previous tweets up to a limit of 3'200.
+First you need to click on the "connect app" button from your laptop or desktop or click on this link, then click on "connect" under the Twitter logo.
+This will bring you on our Twitter bridge.
+
+Once there you'll have to sign in using the button on the top right corner of your screen and enter your credentials.
+This will trigger a popup to open to ask you to allow Twitter to publish on your Pryv, it will also create a Twitter stream to store your data
+The next window will enable you to choose the Tweets that should be sent to your Pryv.
+The first box will enable you to refine the Tweets that will be sent to your Pryv:
+you can choose to import all tweets, only favorites or those that fits a specific text.
+
+Finally you will also be enabled to import your previous tweets up to a limit of 3'200.
 
 ### What do you mean by live forwarding?
 Live forwarding means that we will download all new items matching your Twitter search or your new Withings data to your Pryv account in real time. 
 
 # Privacy
-
 ## HIPAA
 ### How my data is protected by HIPAA?
-As being HIPAA compliant, Pryv protects your data by establishing safeguards and policies guaranteeing the highest security standards for health data protections are applied.
+As being HIPAA compliant, Pryv protects your data by establishing safeguards
+and policies guaranteeing the highest security standards for health data protections are applied.
  
-Pryv does not access the content of your data and thus consider and treat all of it as of the highest sensitivity. That means that even non-sensitive data is treated as privately and securely as health one.
+Pryv does not access the content of your data and thus consider and treat all of it as of the highest sensitivity.
+That means that even non-sensitive data is treated as privately and securely as health one.
  
 Pryv do not use or disclose your data.
  
 Learn more How the Privacy and Security Rules protect your health information?
 
 ### What does HIPAA bring me?
-Pryv complies with  Health Insurance Portability and Accountability Act (HIPAA) regulations. HIPAA establishes standards around privacy, security, and breach notification to protect individually identifiable health information.
+Pryv complies with  Health Insurance Portability and Accountability Act (HIPAA) regulations.
+HIPAA establishes standards around privacy, security, and breach notification to protect individually identifiable health information.
+
 Learn more about how HIPAA Privacy and Security rules protect your health information
-
-
-# Community
-
-## Add features
-At Pryv, we love hearing from you about how you’re using our service and what we could do to improve your experience. While we do have a clear vision for Pocket’s future, we are happy to provide you with what you feel to be important so please do not hesitate to go wild and to be imaginative!
-### Duration
-I can't add a duration while adding an event, I can add a duration while in edit mode but not before.
-## Connected apps & services wishlist
-## Feature requests for the iOS app
-## Feature requests for browser version
-### Import picture window
-I just encountered something weird: when I import my pictures and get to the import window and click outside of it (for support for instance) the window just disappeared! What happened to my pictures or my importation?
-## General discussion
-### Chrome store
-Have you though of using the chrome store to showcase your app?
-## IFTTT recipies
-Here you can simply share with other Pryv users your best recipes to get content in and out of Pryv

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,213 @@
+# General
+## FAQ
+### What is the best way to raise an issue?
+If you have a precise question it might be already answered on our support page,
+if not we encourage you to raise your point in our community center where you can find help from us or other users.
+More and more of our apps also have a "help" (or "support") button built-in, which we recommend.
+If you would rather address us directly send us an email at support@pryv.com: we are bound to confidentiality by our HIPAA certificate.
+
+### How do I create an account?
+To create your account simply click on this link. Then simply follow the steps that are required, to create your account we will need
+your email address: this way we can help you if you were to loose your password or contact you to tell you about our latest news
+a username of your choosing as long as no one else took it
+a password that has a minimum of 6 characters
+a location to store your data of your choosing.
+The last point is rather important as by choosing the location that is the closest to you, you grant yourself a way to complain in case your data are stolen or if you'd rather benefit from your homeland regulation for data protection.
+### What can I do with Pryv?
+We designed Pryv to support many different usages and are working to provide you with more ways to really feel in full control of your data. That being said we also created test/demo accounts such as Christine. Christine is an active mother: she loves to run and have a devouring passion for arts. She enjoys taking care of her family and cooking. We invite you to check her account and why not add it to your Pryv. Be sure that other will come in the days to come.
+
+We're looking forward to see how you're going to use it, please feel free to share with us or with other how you use Pryv.
+
+### How much data can I upload on my Prvy?
+At the moment there is no storage limit, but we may get in touch to discuss if your account gets big enough to become an issue for us. In the short term we will set a reasonable limit for uploads to make things clearer.
+As we get closer to the end of our Beta phase, we will define the exact conditions for free and paid/sponsored accounts. As the infrastructure required to run Pryv isn't free, paid accounts are the only real guarantee we can offer that our goals are aligned with yours (so that you are not the product). We'll provide more information about future pricing on our website as soon as we can.
+
+### What is a stream?
+A stream is a category for content. It regroups content that occurs in a given context such as traveling, family, hobbies, games, friends, etc. A stream represents an aspect of your life.
+A stream can have sub-streams. For example "Traveling" could contain "Belgium", "Sweden" and "Brittany"; "Family" could contain "kids", "grandma" and "dog".
+
+### What is a slice of life?
+A slice of life is a set of streams that you want to view together. For example, you will probably want to view your running performance together with your health metrics and maybe share that with your trainer. Or view your travel logs, kids photos and notes to share with Grandma. 
+### What about Android?
+We are fully aware of the growing number of Android users and we will deliver Pryv for Android as soon as possible. We plan that to be by the end the year. 
+## ACCOUNT & REGISTRATION
+### I was asked where I want my data stored, what does that mean?
+Pryv gives you full control over your data. That also means choosing the country and thus the legal environment in which your data is stored. This enables you to:
+Put your data where you think it is the safest for you
+Defend your rights and protect your privacy in the legal frame you choose
+
+# Browser / Web app
+
+## FAQ
+Here you can ask us anything regarding the browser version of Pryv. Feel free to tell us about any bug, UI issue or glitches you may have found.
+### How can I change my profile picture?
+To change your Pryv profile picture, you have to set up a Gravatar account with the same email you are using on Pryv (https://en.gravatar.com/ ) Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+### How can I change my password?
+To change your password click on your username to access the setting panel. Once openned click on the "security" panel to access password modification 
+### How can I disconnect apps from my Pryv?
+To disconnect apps from your Pryv you need to go in you setting panel that is accessible when you click on your username on the top right corner of your screen. The click on setting to get to the list of apps that are currently connected to your account. To disconnect any of them simply click on "disconnect" and the app will disappear from your list. 
+### Will I be able to download my data back to my computer?
+There will definitely be an export function: as we often say your data is yours and yours alone. If you wish to retrieve your data back to your computer you definitely need to be able to. We are working on it as we speak but we'd be very interested to know under which format you'd like to receive your data so don't hesitate to leave us a comment or to contact us. 
+### How can I add, delete, move or rename a stream?
+Today you can create stream when adding new items to your Pryv with our web app, when importing pictures, notes or position from the CSV importer or with Pryv for iOS.
+At the moment there is no way to manage your streams other than when adding new items, we are aware that the absence of stream management is one of the biggest pain at the moment and we are planning to solve that by releasing an update for Pryv in the days to come. We'll keep you updated on our blog.
+### I have imported pictures (or other content) but I don't see them, why?
+f after importing pictures (or other content, e.g. with the CSV importer) you don't see them, or only see some of them, check the period of time (and maybe the streams) you're looking at. Most likely what you've added is outside (past) the currently selected time frame, which you can adjust with the bottom navigation controls. 
+### How do I edit positions?
+To edit a geographical position, choose Edit, then just drag the marker to the desired location on the map (and don't forget to Save your change).
+In the future we'll add location search to make adding and editing positions easier.
+### How to import more than one picture at the same time?
+In the window that opens to select what file to upload, you can select multiple files by keeping pressed SHIFT or COMMAND (Mac) / CONTROL (Linux/Windows) on your keyboard. 
+### Which browser should I be using?
+Our reference browser for development is Chrome for Mac, Windows and Linux but Pryv also works well on Firefox. As of today we have not yet been able to seriously test it on other browsers, so we can't promise the best of experiences on the likes of Safari, Opera or Internet Explorer. Please tell us in the comments if you would like us to work more on one or the other. 
+
+## SHARING & SLICES
+### What happens when I share my content through Facebook or Twitter?
+When you share a slice of life on Facebook, Twitter or other services you only share an access to your content, i.e. you do not provide the content itself. This enables you to share without giving up your rights to your content as everything stays on your account (and thus under your control). It also means you can revoke access to your content in a few clicks, immediately removing access rights for whomever had received the sharing link. 
+### Someone shared a slice with me, how can I keep it in my account?
+In Pryv you can not only see what your relatives or friends share with you, but you can also seamlessly integrate it into your own Pryv account. To do so, when you've opened the sharing link on Pryv (and signed in if necessary), simply open the left side drawer and choose Follow this slice. 
+Once that's done, just go to your own account to see the followed slice the same way you see your own content, including real-time updates.
+
+### How can I share content?
+Pryv allows you to share content with friends or relatives whether or not they have a Pryv account, by giving them access to a selected set of streams (i.e. a slice of life).
+To share a slice of life, open the left panel , select the desired streams (checking the corresponding content in the view that updates in real time), then choose Share a slice. You can then enter a name to identify that shared slice, change access permissions if needed (more on that below), double-check the streams you're sharing, and after you've confirmed (with the Share button) share the link on Twitter, Facebook or with an e-mail.
+ 
+What is actually shared?
+In Pryv you don't share individual content items (like a picture, a note, etc.), you share streams of content. People you've shared with will then be able to access all the content in those selected streams, including past and new content (updated in real time), with even the ability to contribute if you choose so. You can see for yourself what a shared slice can look like by opening Christine's sharing.
+ 
+About permissions
+There are 3 levels of permissions:
+Allow read only: people you share with can only view the content
+Allow contributing content: people can also add and edit content (pictures, notes, etc.)
+Allow managing content and streams: people can contribute but also add, edit and delete sub-streams
+ 
+Your feedback
+Feel free to tell us what you use sharing for (or suggest other ways you'd like to share content) in the comments. We're looking forward to it.
+
+### I added a shared slice, does it consume my storage?
+No. When someone shares a slice with you the data remains on that person's account. This means the data does not count as part of your personal storage. 
+### I shared a slice but how can I revoke it?
+Open the left panel and go to Manage slices, which lists all the slices you have shared. From there you can locate your slice and delete it instantly. Once deleted no one else will be able to access it anymore. 
+
+## QUICK SETUP
+### How can I change my profile picture?
+To change your Pryv profile picture, you have to set up a Gravatar account with the same email you are using on Pryv (https://en.gravatar.com/ ) Then the uploaded picture will be automatically updated as your Pryv profile picture. 
+### How can I see more of my content?
+The main navigation tool on Pryv is the time bar at the bottom. By clicking on its elements you'll be able to navigate through years, months, weeks or days. For more customization you cal also choose the "custom" button to select the time frame you wish to display.
+You can also choose to reduce or increase the amount of streams to display by using the drawer on the right side of your screen. Check or uncheck the streams you want to see
+
+### How can I add a note?
+To add a note click on the "add content" menu  and then on the note button.
+Once in the note edition mode just type your note, choose the stream you want your data to be stored in and click on add to save. You can also add tags or a description to it before saving.
+
+### How can I add a position?
+As for all content creation first click on "add content"  and then on position.
+When in the "add position" menu you'll be asked if you want your position to be added, if yes agree to the question and if not you'll automatically be located in Switzerland. To change the position drag and drop the red marker to your desired position.
+Then choose the stream where you want this data to be saved and click on add to save the position.
+
+### How can I do add pictures?
+From the browser you can add pictures by using the "add content" button.
+When you are in the add content menu simply choose the picture menu and click on "select pictures to upload". You can import multiples elements by holding the shift button down when clinking on the pictures you want to import. 
+Choose the stream where you want your pictures to be and then on import. Wait for the window to close itself to display the pictures in your Pryv.
+
+### I just created an account, what now?
+Congratulations and welcome on Pryv. Before arriving to your account you'll see a few slides describing what Pryv is as well as Christine's account. With Christine you'll see a great deal of what Pryv is about.
+You will then have the choice between adding your own content (pictures, notes or position) or adding an app of your choosing.
+We are now going to see how to add your content, as there will be a dedicated article for each app connexion. First you will need to click on the "add content" button. It's located on your top left screen.
+By clicking on "add content" you will open the following window. From here you can choose between adding a note, a picture or a location or even upload a CSV file.
+ 
+Once you've added your content you'll need to choose the stream in which you want the content to be. Your streams will appear on the right of your window, just click on one to choose it or to open the substream creation menu. If you decide to create a new stream your content will be imported in it at the same time as the stream will be create.
+ 
+When this is done simply enjoy the visualization of your content and why not share it with friends?
+
+
+# iOS app
+
+## SUPPORT RELATIVE TO PRYV ON IOS
+### Why do I keep seeing the red slides?
+The 3 onboarding slides appear when there is no content to display (this is an issue that will be fixed in the future). To make them disappear, either add content or select streams with content in the left drawer. 
+### Where can I see all the content I enter into the app?
+To access all the content you create in Pryv iOS (or other apps like Pryv At or Pryv OSX), we invite you to sign into your account from pryv.me from a laptop or desktop computer. You'll be able to view, navigate and enjoy all your content at a glance with our dynamic visualization. 
+### When I tap on '+' to add content there is a long empty list, what's that for?
+That space is used to display shortcuts for the most recently added content. Those shortcuts are automatically created each time you add a new item to your Pryv from the app, and save you time by pre-selecting the content type, stream and tags for new content.  
+### Why can't I see my positions in the app?
+For the moment the iOS app does not support positions. We'll add that in the future, but in the meantime you can use the very simple app Pryv At which does just that. Thanks for your patience and support. 
+
+# Connected apps
+
+## CSV IMPORTER
+### A step by step guide to importing CSV files
+We got a few questions about how to import multiple numerical data into Pryv without going trough the iPhone app and we wanted to provide you with a complete guide on how to use our CSV importer.
+1. Get your CSV file, it's the only format that can be uploaded right now but save your excel files as CSV by choosing to "save as" and selecting the CSV format in the drop down menu.
+2. Get to the CSV importer either from your connected app section or by using this link.
+3. Start by signing in in using the red button on the top right button
+4. Once logged in simply drag and drop your file onto the delimited zone or click on it to open your explorer / finder
+5. The next step requires you to select the unit you want to import, you can either use the search bar at the top or scroll in the menu. You'll need to select the type and the unit, both are required to continue, as long as both are not selected you will not be able to continue.
+6. You then need to select the content of each column, you'll need at least a "time" and a "content" field to continue. When you select time be careful of the format, you might need to change the default selection to fit your requirements, you can check it with the date inserted in brackets that displays how you date will be imported. Do not forget to skip the first row if you used it to enter the title of the column.
+7. Then simply select which stream you would like your data to be imputed or create a new one by entering its name, choosing where you want it to be and clinking on the + then select "confirm".
+8. Once the download is complete you can either cancel it by using the "rollback" button, start importing a new CSV file with "back" or simply enjoy your content in your Pryv by clicking on "go to my Pryv".
+ 
+We hope you'll enjoy importing you CSV files and enjoy them in your own Pryv. Would you have any issue please do not hesitate to contact us or to leave us a comment below.
+
+### I can't find my desired unit, what can I do?
+We are aware that there are thousand of types of units and so far we've tried to offer all most used ones and those for which we had the most demand. If you feel that some unique or even original measure you'd like to use is missing please don't hesitate to add a comment below or contact us directly. 
+### What is EpochTime?
+If you are new to CSV files you may be surprised to see the word EpochTime in your time column. EpochTime is a way to count time in seconds, therefore you may have something like that: "1372507199.9995", in everyday English it is the same thing as Sat, Jun 29 2013 1:59 PM). If you are dealing with this kind of time stamp and you want to import them to your Pryv no problem: just enter X (in upper case) instead of the time and we will translate it instantly for you. 
+
+## PRYV AT
+### How can I limit or increase the amount of positions taken?
+There are several options you can use to increase or decrease the amount of position taken by the app. You can modify the distance between each new captured position or the time between new captures by simply going on the setting page on the bottom right corner of the screen.
+By modifying theses settings you will also change the impact that the app will have on your battery: the more position you want to take the more battery it will consume, if, on another hand, you're just looking for a simple way to keep simple records of your whereabouts you can limit the amount of position taken and by doing so increase you battery lifespan.
+
+
+## PRYV FOR OS X
+### Can I import multiple elements at once?
+At the moment you can only import events one by one but multiple elements importation is something that should be arriving very soon so stay tunned and don't miss your app updates. 
+
+## 3RD PARTY APPS
+### How can I add my Withings account to my Pryv?
+The first thing you'll need to do to connect your Withings account is to go on "connect apps" from your desktop or click on this link.
+This will trigger a new window to open where you'll be asked to login from the button on the top right corner of your screen. This will open a pop-up to ask you the permission to create a new stream dedicated to receiving your Withings data. If you decide to reject your data won't be uploaded and the Withings stream won't be created.
+Once you accepted you will get a last confirmation screen to tell you that all new data will now be imported to your Pryv account in its dedicated stream.
+
+### How can I connect with my Twitter account to my Pryv?
+First you need to click on the "connect app" button from your laptop or desktop or click on this link, then click on "connect" under the Twitter logo. This will bring you on our Twitter bridge.
+Once there you'll have to sign in using the button on the top right corner of your screen and enter your credentials. This will trigger a popup to open to ask you to allow Twitter to publish on your Pryv, it will also create a Twitter stream to store your data
+The next window will enable you to choose the Tweets that should be sent to your Pryv. The first box will enable you to refine the Tweets that will be sent to your Pryv: you can choose to import all tweets, only favorites or those that fits a specific text. Finally you will also be enabled to import your previous tweets up to a limit of 3'200.
+
+### What do you mean by live forwarding?
+Live forwarding means that we will download all new items matching your Twitter search or your new Withings data to your Pryv account in real time. 
+
+# Privacy
+
+## HIPAA
+### How my data is protected by HIPAA?
+As being HIPAA compliant, Pryv protects your data by establishing safeguards and policies guaranteeing the highest security standards for health data protections are applied.
+ 
+Pryv does not access the content of your data and thus consider and treat all of it as of the highest sensitivity. That means that even non-sensitive data is treated as privately and securely as health one.
+ 
+Pryv do not use or disclose your data.
+ 
+Learn more How the Privacy and Security Rules protect your health information?
+
+### What does HIPAA bring me?
+Pryv complies with  Health Insurance Portability and Accountability Act (HIPAA) regulations. HIPAA establishes standards around privacy, security, and breach notification to protect individually identifiable health information.
+Learn more about how HIPAA Privacy and Security rules protect your health information
+
+
+# Community
+
+## Add features
+At Pryv, we love hearing from you about how you’re using our service and what we could do to improve your experience. While we do have a clear vision for Pocket’s future, we are happy to provide you with what you feel to be important so please do not hesitate to go wild and to be imaginative!
+### Duration
+I can't add a duration while adding an event, I can add a duration while in edit mode but not before.
+## Connected apps & services wishlist
+## Feature requests for the iOS app
+## Feature requests for browser version
+### Import picture window
+I just encountered something weird: when I import my pictures and get to the import window and click outside of it (for support for instance) the window just disappeared! What happened to my pictures or my importation?
+## General discussion
+### Chrome store
+Have you though of using the chrome store to showcase your app?
+## IFTTT recipies
+Here you can simply share with other Pryv users your best recipes to get content in and out of Pryv

--- a/source/index.html
+++ b/source/index.html
@@ -1066,7 +1066,7 @@
         <a href="javascript:void(0)" ><span class="icon ss-piechart"></span> <span data-i18n="nav.actions.connectApps"></span></a>
       </li>
       <li id="requestHelp">
-        <a href="mailto:support@pryv.com"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
+        <a href="javascript:void(0)"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/source/index.html
+++ b/source/index.html
@@ -1066,7 +1066,7 @@
         <a href="javascript:void(0)" ><span class="icon ss-piechart"></span> <span data-i18n="nav.actions.connectApps"></span></a>
       </li>
       <li id="requestHelp">
-        <a href="mailto:support@pryv.com"><span class="icon ss-help"></span></a>
+        <a href="mailto:support@pryv.com"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/source/index.html
+++ b/source/index.html
@@ -1066,7 +1066,7 @@
         <a href="javascript:void(0)" ><span class="icon ss-piechart"></span> <span data-i18n="nav.actions.connectApps"></span></a>
       </li>
       <li id="requestHelp">
-        <a href="http://pryv.com/helpdesk/"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
+        <a href="http://pryv.com/helpdesk/" target="_blank"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/source/index.html
+++ b/source/index.html
@@ -1065,6 +1065,9 @@
       <li id="connectApps">
         <a href="javascript:void(0)" ><span class="icon ss-piechart"></span> <span data-i18n="nav.actions.connectApps"></span></a>
       </li>
+      <li id="requestHelp">
+        <a href="mailto:support@pryv.com"><span class="icon ss-help"></span></a>
+      </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">
         <li id="toMyPryv">

--- a/source/index.html
+++ b/source/index.html
@@ -1108,22 +1108,5 @@
   <!-- /.modal-dialog -->
 </div>
 <!-- /.modal -->
-<!-- Zendesk "help" tab snippet -->
-<script type="text/javascript" src="//assets.zendesk.com/external/zenbox/v2.6/zenbox.js"></script>
-<style type="text/css" media="screen, projection">
-  @import url(//assets.zendesk.com/external/zenbox/v2.6/zenbox.css);
-</style>
-<script type="text/javascript">
-  if (typeof(Zenbox) !== "undefined") {
-    Zenbox.init({
-      dropboxID:   "20259791",
-      url:         "https://pryv.zendesk.com",
-      tabTooltip:  "Get support",
-      tabImageURL: "https://p3.zdassets.com/external/zenbox/images/tab_help_right.png",
-      tabColor:    "#333",
-      tabPosition: "Right"
-    });
-  }
-</script>
 </body>
 </html>

--- a/source/index.html
+++ b/source/index.html
@@ -1066,7 +1066,7 @@
         <a href="javascript:void(0)" ><span class="icon ss-piechart"></span> <span data-i18n="nav.actions.connectApps"></span></a>
       </li>
       <li id="requestHelp">
-        <a href="javascript:void(0)"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
+        <a href="http://pryv.com/helpdesk/"><span class="icon ss-help"></span> <span data-i18n="nav.actions.requestHelp"></span></a>
       </li>
     </ul>
     <ul class="nav navbar-nav navbar-right">

--- a/source/locales/dev/browser.json
+++ b/source/locales/dev/browser.json
@@ -155,6 +155,7 @@
       "followSlice": "Follow this slice",
       "goToMyPryv": "Me",
       "manageSlices": "Manage slices",
+      "requestHelp": "Request help",
       "settings": "Settings",
       "shareSlice": "Share a slice of life",
       "signIn": "Sign in",

--- a/source/styles/styles.css
+++ b/source/styles/styles.css
@@ -1552,26 +1552,6 @@ nav .gravatar {
   padding: 10px 15px;
 }
 
-
-/* Zendesk tab */
-#zenbox_tab {
-  top: inherit !important;
-  bottom: 80px; /* i.e. align with treemap bottom */
-  right: -11px;
-  border: none !important;
-  border-radius: 3px;
-  overflow: hidden;
-  opacity: 0.25;
-}
-#zenbox_tab:hover, #zenbox_tab:focus {
-  -webkit-box-shadow: 0 0 0 1px #FFF;
-  box-shadow: 0 0 0 1px #FFF;
-  opacity: 1;
-}
-#zenbox_tab img {
-  margin: -4px;
-}
-
 /* Logo "beta" mention */
 
 #logo-beta-mention {

--- a/source/tree/TreeMap.js
+++ b/source/tree/TreeMap.js
@@ -78,6 +78,19 @@ var TreeMap = module.exports = function (model) {
     this.showConnectAppsView($modal, this.model.loggedConnection, e.currentTarget);
   }.bind(this));
 
+  Pryv.utility.request({
+    method : 'GET',
+    ssl : 'true',
+    host : 'reg.' + Pryv.utility.urls.defaultDomain,
+    path : '/service/infos',
+    success : function (data) {
+      $('nav #requestHelp').click(function (e) {
+        e.preventDefault();
+        location.href = data.support;
+      }.bind(data));
+    }
+  });
+
   $('.logo-sharing').click(function (e) {
     e.preventDefault();
     var $modal =  $('#pryv-modal').on('hidden.bs.modal', function () {

--- a/source/tree/TreeMap.js
+++ b/source/tree/TreeMap.js
@@ -78,19 +78,6 @@ var TreeMap = module.exports = function (model) {
     this.showConnectAppsView($modal, this.model.loggedConnection, e.currentTarget);
   }.bind(this));
 
-  Pryv.utility.request({
-    method : 'GET',
-    ssl : 'true',
-    host : 'reg.' + Pryv.utility.urls.defaultDomain,
-    path : '/service/infos',
-    success : function (data) {
-      $('nav #requestHelp').click(function (e) {
-        e.preventDefault();
-        location.href = data.support;
-      }.bind(data));
-    }
-  });
-
   $('.logo-sharing').click(function (e) {
     e.preventDefault();
     var $modal =  $('#pryv-modal').on('hidden.bs.modal', function () {


### PR DESCRIPTION
We decided to drop Zendesk and instead use a simple mailto support@pryv.com to answer user requests.
This is implemented by removing Zendesk 'help' button (bottom right of the dashboard) and replacing it with a mailto button.

For now, the new button is located top left but suggestions for other emplacement/style are welcome.
Also, the Zendesk FAQ is saved as markdown document for future use (either in Pryv website or here).