### PR TITLE
Add/bringback caller id notion with sharings

### DIFF
--- a/source/Model.js
+++ b/source/Model.js
@@ -10,6 +10,8 @@ var MonitorsHandler = require('./model/MonitorsHandler.js'),
     TimeLine = require('./timeframe-selector/timeframe-selector.js'),
     UnknownUserView = require('./view/error/unknown-user.js'),
     PUBLIC_TOKEN = 'public',
+    CALLERID_SEPARATOR_CLIENT = '+',
+    CALLERID_SEPARATOR_API = ' ',
     themes = require('./themes/index'),
     toShowWhenLoggedIn = ['.logo-sharing', 'nav #addEvent', '.logo-create-sharing',
       'nav #togglePanel', 'nav #settings', 'nav #connectApps'],
@@ -69,8 +71,9 @@ var Model = module.exports = function () {  //setup env with grunt
   if (this.urlSharings.length > 0) {
     this.sharingsConnections = [];
     this.urlSharings.forEach(function (token) {
+      var sharingToken = formatSharingCallerId(token);
       this.sharingsConnections.push(new Pryv.Connection(
-        this.urlUsername, token, {}));
+        this.urlUsername, sharingToken, {}));
     }.bind(this));
     this.setTimeframeScale(this.sharingsConnections[0]);
     $('.logo-subscribe').show();
@@ -443,6 +446,12 @@ function testUsername(username, domain) {
     $('body').html(UnknownUserView);
     $('body').i18n();
   });
+}
+
+// Make sure that the caller id is sent to the API alongside the sharing token
+// by replacing the client separator with the one expected by the API
+function formatSharingCallerId(sharing) {
+  return sharing.replace(CALLERID_SEPARATOR_CLIENT, CALLERID_SEPARATOR_API);
 }
 
 Model.prototype.closeLogin = function () {

--- a/source/Model.js
+++ b/source/Model.js
@@ -451,8 +451,8 @@ function testUsername(username, domain) {
 // Make sure that the caller id is sent to the API alongside the sharing token
 // by replacing the client separator with the one expected by the API
 function formatSharingURI(sharingURI) {
-  var sharing = decodeURIComponent(sharingURI);
-  return sharing.replace(CALLERID_SEPARATOR_CLIENT, CALLERID_SEPARATOR_API);
+  var sharing = sharingURI.replace(CALLERID_SEPARATOR_CLIENT, CALLERID_SEPARATOR_API);
+  return decodeURIComponent(sharing);
 }
 
 Model.prototype.closeLogin = function () {

--- a/source/Model.js
+++ b/source/Model.js
@@ -71,7 +71,7 @@ var Model = module.exports = function () {  //setup env with grunt
   if (this.urlSharings.length > 0) {
     this.sharingsConnections = [];
     this.urlSharings.forEach(function (token) {
-      var sharingToken = formatSharingCallerId(token);
+      var sharingToken = formatSharingURI(token);
       this.sharingsConnections.push(new Pryv.Connection(
         this.urlUsername, sharingToken, {}));
     }.bind(this));
@@ -450,7 +450,8 @@ function testUsername(username, domain) {
 
 // Make sure that the caller id is sent to the API alongside the sharing token
 // by replacing the client separator with the one expected by the API
-function formatSharingCallerId(sharing) {
+function formatSharingURI(sharingURI) {
+  var sharing = decodeURIComponent(sharingURI);
   return sharing.replace(CALLERID_SEPARATOR_CLIENT, CALLERID_SEPARATOR_API);
 }
 


### PR DESCRIPTION
Caller id notion was not working with sharings through the Pryv browser because the separator between token and callerid was not matching the one expected by the API (space).

Through this PR, we ensure that the client-side callerid separator (+) is replaced by the API separator (space) before creating the sharing Connections.

It has been tested on a local app-web (with a domain hardcoded to pryv.me) with the following steps:
- Login in Pryv browser
- Share a slice with manage level
- Copy the sharing (from /#sharings) and add a '+callerid' at the end
- Open the modified sharing url in a browser
- Click Add content, Note (make sure the authorized streams match the sharing permissions)
- Check that the createdBy field of the new Event contains the token AND the caller id (separated by a space)